### PR TITLE
[cmake] Bump minimum CMake version to 3.8 (fix #10)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 set(POMEROL2TRIQS_VERSION "0.2")
 
 # Start configuration
-cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
 project(pomerol2triqs CXX)
 set(CMAKE_CXX_STANDARD 17)
 


### PR DESCRIPTION
This is the minimum version that supports `17` as a valid value for `CXX_STANDARD`.