### PR TITLE
Upgrade to TRIQS 2.2 (fix #12)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,7 +103,7 @@ before_script:
 
   # Build and install TRIQS
   - git clone https://github.com/TRIQS/triqs.git triqs.git
-  - pushd triqs.git && git checkout 2.1.0 && popd
+  - pushd triqs.git && git checkout 2.2.1 && popd
   - mkdir triqs.build && pushd triqs.build
   - |
     cmake ../triqs.git                      \

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Installation
 ------------
 
 - Install the latest version of [Pomerol](http://aeantipov.github.io/pomerol/) exact diagonalization library (`master` branch).
-- Install the [TRIQS](http://triqs.github.io/triqs/2.1.x/install.html) library version 2.1.0.
+- Install the [TRIQS](http://triqs.github.io/triqs/2.2.x/install.html) library version 2.2.x.
 - `source <path_to_triqs_install_dir>/share/cpp2pyvars.sh`
 - `source <path_to_triqs_install_dir>/share/triqsvars.sh`
 - `git clone https://github.com/krivenko/pomerol2triqs.git pomerol2triqs.git`

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Installation
 License
 -------
 
-Copyright (C) 2017-2019 Igor Krivenko <igor.s.krivenko @ gmail.com>
+Copyright (C) 2017-2020 Igor Krivenko <igor.s.krivenko @ gmail.com>
 
 With contributions from Hugo U.R. Strand
 

--- a/c++/chi.cpp
+++ b/c++/chi.cpp
@@ -1,7 +1,7 @@
 /**
  * pomerol2triqs
  *
- * Copyright (C) 2017-2019 Igor Krivenko <igor.s.krivenko @ gmail.com>
+ * Copyright (C) 2017-2020 Igor Krivenko <igor.s.krivenko @ gmail.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/c++/g.cpp
+++ b/c++/g.cpp
@@ -1,7 +1,7 @@
 /**
  * pomerol2triqs
  *
- * Copyright (C) 2017-2019 Igor Krivenko <igor.s.krivenko @ gmail.com>
+ * Copyright (C) 2017-2020 Igor Krivenko <igor.s.krivenko @ gmail.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/c++/g2.cpp
+++ b/c++/g2.cpp
@@ -1,7 +1,7 @@
 /**
  * pomerol2triqs
  *
- * Copyright (C) 2017-2019 Igor Krivenko <igor.s.krivenko @ gmail.com>
+ * Copyright (C) 2017-2020 Igor Krivenko <igor.s.krivenko @ gmail.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/c++/g2.cpp
+++ b/c++/g2.cpp
@@ -177,7 +177,7 @@ namespace pomerol2triqs {
     else
       g2 = compute_g2<w_nu_nup_t>(p.gf_struct, mesh_bff, p.block_order, p.blocks, filler);
 
-    g2() = mpi_all_reduce(g2(), comm);
+    g2() = mpi::all_reduce(g2(), comm);
 
     return g2;
   }
@@ -250,7 +250,7 @@ namespace pomerol2triqs {
     };
 
     auto g2 = compute_g2<w_l_lp_t>(p.gf_struct, mesh, p.block_order, p.blocks, filler);
-    g2() = mpi_all_reduce(g2(), comm);
+    g2() = mpi::all_reduce(g2(), comm);
 
     return g2;
   }

--- a/c++/pomerol_ed.cpp
+++ b/c++/pomerol_ed.cpp
@@ -1,7 +1,7 @@
 /**
  * pomerol2triqs
  *
- * Copyright (C) 2017-2019 Igor Krivenko <igor.s.krivenko @ gmail.com>
+ * Copyright (C) 2017-2020 Igor Krivenko <igor.s.krivenko @ gmail.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/c++/pomerol_ed.hpp
+++ b/c++/pomerol_ed.hpp
@@ -1,7 +1,7 @@
 /**
  * pomerol2triqs
  *
- * Copyright (C) 2017-2019 Igor Krivenko <igor.s.krivenko @ gmail.com>
+ * Copyright (C) 2017-2020 Igor Krivenko <igor.s.krivenko @ gmail.com>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/c++/pomerol_ed.hpp
+++ b/c++/pomerol_ed.hpp
@@ -30,7 +30,6 @@
 #include <triqs/gfs.hpp>
 #include <triqs/operators/many_body_operator.hpp>
 #include <triqs/hilbert_space/fundamental_operator_set.hpp>
-#include <triqs/mpi/boost.hpp>
 
 #include "g2_parameters.hpp"
 
@@ -58,7 +57,7 @@ namespace pomerol2triqs {
   /// Main solver class of pomerol2triqs
   class pomerol_ed {
 
-    triqs::mpi::communicator comm;
+    boost::mpi::communicator comm;
 
     const bool verbose;
     index_converter_t index_converter;

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -2,7 +2,7 @@
 #
 # pomerol2triqs
 #
-# Copyright (C) 2017-2019 Igor Krivenko <igor.s.krivenko @ gmail.com>
+# Copyright (C) 2017-2020 Igor Krivenko <igor.s.krivenko @ gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/python/version.py.in
+++ b/python/version.py.in
@@ -2,7 +2,7 @@
 #
 # pomerol2triqs
 #
-# Copyright (C) 2017-2019 Igor Krivenko <igor.s.krivenko @ gmail.com>
+# Copyright (C) 2017-2020 Igor Krivenko <igor.s.krivenko @ gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
@egcpvanloon @lyuwen Could you please have a look? Can you successfully compile and run the code with TRIQS 2.2.x now?

With Clang 9, a few unit tests still segfault on my machine. The stack traces lead somewhere in the `cpp2py`-generated glue code, so I am not sure how to debug this issue...

Update: Travis has no issue running the unit tests when everything is built with GCC 7.4.0 or Clang 7.0.0.