### PR TITLE
Add missing using declaration for itertools::range

### DIFF
--- a/c++/pomerol_ed.hpp
+++ b/c++/pomerol_ed.hpp
@@ -45,6 +45,7 @@ namespace pomerol2triqs {
 
   using namespace triqs::gfs;
   namespace mesh = triqs::mesh;
+  using itertools::range;
   using triqs::hilbert_space::gf_struct_t;
 
   using indices_t              = triqs::hilbert_space::fundamental_operator_set::indices_t;


### PR DESCRIPTION
## Summary
- TRIQS unstable no longer exports `itertools::range` into the global namespace
- Add explicit `using itertools::range;` in the `pomerol2triqs` namespace so unqualified `range()` calls compile against current TRIQS

## Test plan
- Build pomerol2triqs against TRIQS unstable (previously fails with `use of undeclared identifier 'range'`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)